### PR TITLE
fix: simplify offset_angle calculation by removing determinant sign adjustement

### DIFF
--- a/addons/soupik/modifications/soup_bone.gd
+++ b/addons/soupik/modifications/soup_bone.gd
@@ -105,7 +105,7 @@ func _process_loop(delta: float) -> void:
 		queue_redraw()
 	if !is_node_ready():
 		await ready
-	offset_angle = get_bone_angle() * sign(global_transform.determinant())
+	offset_angle = get_bone_angle()
 	match transform_mode:
 		TransformMode.IK:
 			handle_position_change(delta)


### PR DESCRIPTION
fix #3

This is tricky one to explain.

_edit: this is probably not true_
~Previously, `offset_angle` was multiplied by `sign(global_transform.determinant())`, which caused a double mirroring of the rotation direction. Since `Bone2D` transforms already inherit the mirrored orientation from the parent, this resulted in the bone’s constraint being evaluated 180° off.~

### Before this path:
#### Test 1:
Everything ok (**`bone_angle` is positive**, `global_modification.determinant()` is positive on non-mirrored and negative on mirrored.)

![no bone angle](https://github.com/user-attachments/assets/9d127311-bd3a-4144-ab19-6155873971fb)

(Bone angle 0° was not a great example. Lets say we have 1° to cheese the math)
Non-mirrored: `1° * 1 = 1°` offset (`bone_angle * det`)
Mirrored: `1° * -1 = -1°` offset (`bone_angle * det`)
**Offset is different** for both of them.

So far everything looks fine. Let's break it.

#### Test 2: 
Broken on mirrored (**`bone_angle` is negative**, `global_modification.determinant()` is positive on non-mirrored and negative on mirrored.
![negative bone angle](https://github.com/user-attachments/assets/90c18a00-70de-4c79-936b-9c7303ee54d3)

Non-mirrored: `-1° * 1 = -1°` offset (`bone_angle * det`)
Mirrored: `-1° * -1 = 1°` offset (`bone_angle * det`)
**Offset is different** for both of them **but other way around** (I have no idea if that's good or bad 😫)

And yet, this was actually the biggest clue as to why the limit is outside the gizmo - no determinant correction is performed during rendering the gizmo but it is during computing rotation limit.



### After this path:

![negative bone angle after](https://github.com/user-attachments/assets/1dbc985e-78fe-43c8-b5b1-9b8a24b71f06)

### Test project:

The test project (with actual version of SoupIK before this path)

[-soup-bones-test.zip](https://github.com/user-attachments/files/23282216/-soup-bones-test.zip)
